### PR TITLE
Fix for ALF-21849

### DIFF
--- a/src/main/java/org/alfresco/service/namespace/DynamicNamespacePrefixResolver.java
+++ b/src/main/java/org/alfresco/service/namespace/DynamicNamespacePrefixResolver.java
@@ -139,7 +139,7 @@ public class DynamicNamespacePrefixResolver implements NamespaceService
        {
           uris.addAll(delegate.getURIs());
        }
-       uris.addAll(map.keySet());
+       uris.addAll(map.values());
        return uris;
     }
 }

--- a/src/test/java/org/alfresco/service/namespace/DynamicNameSpaceResolverTest.java
+++ b/src/test/java/org/alfresco/service/namespace/DynamicNameSpaceResolverTest.java
@@ -4,26 +4,28 @@
  * %%
  * Copyright (C) 2005 - 2016 Alfresco Software Limited
  * %%
- * This file is part of the Alfresco software. 
- * If the software was purchased under a paid Alfresco license, the terms of 
- * the paid license agreement will prevail.  Otherwise, the software is 
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
  * provided under the following open source license terms:
- * 
+ *
  * Alfresco is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Alfresco is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
 package org.alfresco.service.namespace;
+
+import java.util.Collection;
 
 import junit.framework.TestCase;
 
@@ -34,7 +36,7 @@ public class DynamicNameSpaceResolverTest extends TestCase
     {
         super();
     }
-    
+
     public void testOne()
     {
         DynamicNamespacePrefixResolver dnpr = new DynamicNamespacePrefixResolver(null);
@@ -44,25 +46,25 @@ public class DynamicNameSpaceResolverTest extends TestCase
         dnpr.registerNamespace("oneagain", "http:/namespace/one");
         dnpr.registerNamespace("four", "http:/namespace/one");
         dnpr.registerNamespace("four", "http:/namespace/four");
-        
+
         assertEquals("http:/namespace/one", dnpr.getNamespaceURI("one"));
         assertEquals("http:/namespace/two", dnpr.getNamespaceURI("two"));
         assertEquals("http:/namespace/three", dnpr.getNamespaceURI("three"));
         assertEquals("http:/namespace/one", dnpr.getNamespaceURI("oneagain"));
         assertEquals("http:/namespace/four", dnpr.getNamespaceURI("four"));
         assertEquals(null, dnpr.getNamespaceURI("five"));
-        
+
         dnpr.unregisterNamespace("four");
         assertEquals(null, dnpr.getNamespaceURI("four"));
-        
+
         assertEquals(0, dnpr.getPrefixes("http:/namespace/four").size());
         assertEquals(1, dnpr.getPrefixes("http:/namespace/two").size());
         assertEquals(2, dnpr.getPrefixes("http:/namespace/one").size());
-        
-        
+
+
     }
-    
-    
+
+
     public void testTwo()
     {
         DynamicNamespacePrefixResolver dnpr1 = new DynamicNamespacePrefixResolver(null);
@@ -74,7 +76,7 @@ public class DynamicNameSpaceResolverTest extends TestCase
         dnpr1.registerNamespace("four", "http:/namespace/four");
         dnpr1.registerNamespace("five", "http:/namespace/five");
         dnpr1.registerNamespace("six", "http:/namespace/six");
-        
+
         DynamicNamespacePrefixResolver dnpr2 = new DynamicNamespacePrefixResolver(dnpr1);
         dnpr2.registerNamespace("a", "http:/namespace/one");
         dnpr2.registerNamespace("b", "http:/namespace/two");
@@ -84,7 +86,7 @@ public class DynamicNameSpaceResolverTest extends TestCase
         dnpr2.registerNamespace("f", "http:/namespace/four");
         dnpr2.registerNamespace("five", "http:/namespace/one");
         dnpr2.registerNamespace("six", "http:/namespace/seven");
-        
+
         assertEquals("http:/namespace/one", dnpr2.getNamespaceURI("one"));
         assertEquals("http:/namespace/two", dnpr2.getNamespaceURI("two"));
         assertEquals("http:/namespace/three", dnpr2.getNamespaceURI("three"));
@@ -92,7 +94,7 @@ public class DynamicNameSpaceResolverTest extends TestCase
         assertEquals("http:/namespace/four", dnpr2.getNamespaceURI("four"));
         assertEquals("http:/namespace/one", dnpr2.getNamespaceURI("five"));
         dnpr2.unregisterNamespace("five");
-        
+
         assertEquals("http:/namespace/five", dnpr2.getNamespaceURI("five"));
         assertEquals("http:/namespace/one", dnpr2.getNamespaceURI("a"));
         assertEquals("http:/namespace/two", dnpr2.getNamespaceURI("b"));
@@ -100,7 +102,7 @@ public class DynamicNameSpaceResolverTest extends TestCase
         assertEquals("http:/namespace/one", dnpr2.getNamespaceURI("d"));
         assertEquals("http:/namespace/one", dnpr2.getNamespaceURI("e"));
         assertEquals("http:/namespace/four", dnpr2.getNamespaceURI("f"));
-        
+
         assertEquals(5, dnpr2.getPrefixes("http:/namespace/one").size());
         assertEquals(2, dnpr2.getPrefixes("http:/namespace/two").size());
         assertEquals(2, dnpr2.getPrefixes("http:/namespace/three").size());
@@ -113,9 +115,34 @@ public class DynamicNameSpaceResolverTest extends TestCase
     public void testGetters()
     {
         DynamicNamespacePrefixResolver dnpr = new DynamicNamespacePrefixResolver(new QNameTest.MockNamespacePrefixResolver());
-        assertNotNull(dnpr.getPrefixes());
-        assertNotNull(dnpr.getURIs());
-        assertNotNull(new DynamicNamespacePrefixResolver());
+
+        dnpr.registerNamespace("one", "http:/namespace/one");
+        dnpr.registerNamespace("two", "http:/namespace/two");
+        dnpr.registerNamespace("three", "http:/namespace/three");
+        dnpr.registerNamespace("oneagain", "http:/namespace/one");
+        dnpr.registerNamespace("four", "http:/namespace/one");
+        dnpr.registerNamespace("four", "http:/namespace/four");
+        dnpr.registerNamespace("five", "http:/namespace/five");
+        dnpr.registerNamespace("six", "http:/namespace/six");
+
+        Collection<String> prefixes = dnpr.getPrefixes();
+        assertNotNull(prefixes);
+        assertTrue(prefixes.contains("one"));
+        assertTrue(prefixes.contains("two"));
+        assertTrue(prefixes.contains("three"));
+        assertTrue(prefixes.contains("four"));
+        assertTrue(prefixes.contains("five"));
+        assertTrue(prefixes.contains("six"));
+        assertTrue(prefixes.contains("oneagain"));
+
+        Collection<String> uris = dnpr.getURIs();
+        assertNotNull(uris);
+        assertTrue(uris.contains("http:/namespace/one"));
+        assertTrue(uris.contains("http:/namespace/two"));
+        assertTrue(uris.contains("http:/namespace/three"));
+        assertTrue(uris.contains("http:/namespace/four"));
+        assertTrue(uris.contains("http:/namespace/five"));
+        assertTrue(uris.contains("http:/namespace/six"));
     }
 
 }


### PR DESCRIPTION
This PR addresses [ALF-21849](https://issues.alfresco.com/jira/browse/ALF-21849) by applying the fix suggested in the JIRA issue. The test for the DynamicNamespacePrefixResolver has been adapted in a separate commit to demonstate the obvious programming mistake and validate the fix works.

Most of the whitespace changes are due to auto-format removing those whitespaces. As per Coding Standards, empty lines should not contain spaces/tabs, though it is unclear on the nature of trailing whitespaces.