### PR TITLE
REPO-3435 : upgrade to Jackson 2.9.4 (includes CVE-2017-17285) for AC…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,13 +197,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId> 
             <artifactId>jackson-core</artifactId> 
-            <version>2.8.10</version> 
+            <version>2.9.4</version> 
         </dependency>
         
         <dependency> 
             <groupId>com.fasterxml.jackson.core</groupId> 
             <artifactId>jackson-annotations</artifactId> 
-            <version>2.8.10</version> 
+            <version>2.9.4</version> 
         </dependency> 
 
         <dependency>


### PR DESCRIPTION
upgrade to Jackson 2.9.4