### PR TITLE
REPO-4519: Fix issue of tika-parsers library to respect dependencyManagement version of pdfbox 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,16 @@
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-parsers</artifactId>
             <version>1.17-20180201-alfresco-patched</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.pdfbox</groupId>
+                    <artifactId>pdfbox</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
         </dependency>
         <dependency>
             <groupId>org.gagravarr</groupId>


### PR DESCRIPTION
- It seems currently when `alfresco-data-model` is called in other maven projects it still picks up `pdfbox` version of `1.8.4` when it has a `dependencyManagement` definition to override and use an explicit version of `1.8.16-alfresco-patched`

Ref:  https://github.com/Alfresco/alfresco-data-model/blob/support/SP/6.28.N/pom.xml#L292
But when compiled in other projects it does not reflect the correct version:
```
[INFO] \- org.alfresco:alfresco-data-model:jar:6.28.7:compile
[INFO]    \- org.apache.tika:tika-parsers:jar:1.6-20180308-alfresco-patched:compile
[INFO]       \- org.apache.pdfbox:pdfbox:jar:1.8.4:compile
```