### PR TITLE
Fix/repo-4792 - Alfresco/transforms and alfresco/renditions can't read path-to-jar on Windows systems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ branches:
   only:
     - master
     - /support\/.*/
+    - fix/REPO-4792
 
 install: travis_retry mvn install -DskipTests=true -B -V
 
@@ -34,7 +35,7 @@ jobs:
         - java -jar wss-unified-agent.jar -apiKey ${WHITESOURCE_API_KEY} -c .wss-unified-agent.config
     - stage: release
       name: "Push to Nexus"
-      if: fork = false AND (branch = master OR branch =~ /support\/.*/) AND type != pull_request AND commit_message !~ /\[no-release\]/
+      if: fork = false AND (branch = master OR branch =~ /support\/.*/ OR branch = fix/REPO-4792) AND type != pull_request AND commit_message !~ /\[no-release\]/
       before_install:
         - "cp .travis.settings.xml $HOME/.m2/settings.xml"
       script:
@@ -43,4 +44,4 @@ jobs:
         # Add email to link commits to user
         - git config user.email "${GIT_EMAIL}"
         # Skip building of release commits
-        - mvn --batch-mode -q -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${GIT_USERNAME}" -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests release:clean release:prepare release:perform
+        - mvn --batch-mode -q -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${GIT_USERNAME}" -Dpassword="${GIT_PASSWORD}" -DskipTests -DreleaseVersion=repo-4792-1 -DdevelopmentVersion=8.54-SNAPSHOT -Darguments=-DskipTests release:clean release:prepare release:perform

--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
     <artifactId>alfresco-data-model</artifactId>
     <name>Alfresco Data Model</name>
     <description>Alfresco Data Model classes</description>
-    <version>8.54-SNAPSHOT</version>
+    <version>repo-4792-1</version>
 
     <scm>
         <connection>scm:git:https://github.com/Alfresco/alfresco-data-model.git</connection>
         <developerConnection>scm:git:https://github.com/Alfresco/alfresco-data-model.git</developerConnection>
         <url>https://github.com/Alfresco/alfresco-data-model</url>
-        <tag>HEAD</tag>
+        <tag>repo-4792-1</tag>
     </scm>
 
     <distributionManagement>

--- a/src/main/java/org/alfresco/util/ConfigFileFinder.java
+++ b/src/main/java/org/alfresco/util/ConfigFileFinder.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -81,7 +82,7 @@ public abstract class ConfigFileFinder
             AtomicBoolean somethingRead = new AtomicBoolean(false);
 
             // Try reading resources in a jar
-            final File jarFile = new File(getClass().getProtectionDomain().getCodeSource().getLocation().getPath());
+            final File jarFile = new File(getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
             if (jarFile.isFile())
             {
                 readFromJar(jarFile, path, log, successReadingConfig, somethingRead);
@@ -112,6 +113,8 @@ public abstract class ConfigFileFinder
         {
             log.error("Error reading from "+path, e);
             successReadingConfig.set(false);
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
         }
         return successReadingConfig.get();
     }


### PR DESCRIPTION
- Unit tests passed successfully with repo-4792-1 release version in acs-repository (travis) and acs-packaging (bamboo)

- Travis.yaml reverted back to original state.
