### PR TITLE
REPO-4879 - Remove library org.apache.commons:commons-lang3 from alfr…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,11 +283,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
-        </dependency>
-        <dependency>
             <groupId>org.codehaus.woodstox</groupId>
             <artifactId>woodstox-core-asl</artifactId>
             <version>4.4.1</version>


### PR DESCRIPTION
…esco-data-model project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

